### PR TITLE
Bæta Module-Info í exclude

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,9 @@
           <activeRecipes>
             <recipe>org.openrewrite.java.cleanup.Cleanup</recipe>
           </activeRecipes>
+          <exclusions>
+            <exclude>src/main/java/module-info.java</exclude>
+          </exclusions>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Þegar `mvn rewrite:run`var keyrt til að linta þá yfirskrifaði það `src/main/java/module-info.java`  sem leyddi til allskonar vandamála bætti því við í exclusion list inn í pom.xml skránni, ætti núna að láta skránna í friði