### PR TITLE
Interface comments

### DIFF
--- a/src/main/java/is/hi/flight_booking/interfaces/FlightRepositoryInterface.java
+++ b/src/main/java/is/hi/flight_booking/interfaces/FlightRepositoryInterface.java
@@ -6,15 +6,48 @@ import java.util.ArrayList;
 import is.hi.flight_booking.application.Flight;
 
 public interface FlightRepositoryInterface {
+
+  /**
+   * Takes in a reference to a flight ID and returns a {@link Flight} object with
+   * the same flight ID
+   *
+   * @param flightId a string containing a flight ID
+   * @return the flight with the specified ID
+   * @see Flight
+   */
   public Flight getFlight(String flightId);
 
+  /**
+   * Searches the database in use for flights that fulfill the search criteria set
+   * using the parameters
+   * 
+   * @param depAddress a string containing the place of departure
+   * @param arrAddress a string containing the place of arrival
+   * @param depTime    a {@link LocalDate} object holding the date of departure
+   * @return an {@link ArrayList} of {@link Flight} objects fulfilling the search
+   *         criteria
+   */
   public ArrayList<Flight> searchFlights(String depAddress, String arrAddrss, LocalDate depTime);
 
+  /**
+   * @return ArrayList of {@link Flight} objects in ascending order of price
+   */
   public ArrayList<Flight> getSortedByPrice();
 
+  /**
+   * @return ArrayList of {@link Flight} objects in ascending time order
+   */
   public ArrayList<Flight> getSortedByTime();
 
+  /**
+   * @return ArrayList of {@link Flight} objects in alphabetical order by
+   *         departure address
+   */
   public ArrayList<Flight> getSortedByDeparture();
 
+  /**
+   * @return ArrayList of {@link Flight} objects in alphabetical order arrival
+   *         address
+   */
   public ArrayList<Flight> getSortedByArrival();
 }

--- a/src/main/java/is/hi/flight_booking/interfaces/FlightRepositoryInterface.java
+++ b/src/main/java/is/hi/flight_booking/interfaces/FlightRepositoryInterface.java
@@ -11,9 +11,8 @@ public interface FlightRepositoryInterface {
    * Takes in a reference to a flight ID and returns a {@link Flight} object with
    * the same flight ID
    *
-   * @param flightId a string containing a flight ID
-   * @return the flight with the specified ID
-   * @see Flight
+   * @param flightId  a string containing a flight ID
+   * @return          a {@link Flight} object with the specified ID
    */
   public Flight getFlight(String flightId);
 

--- a/src/test/java/is/hi/flight_booking/mocks/MockFlightRepository.java
+++ b/src/test/java/is/hi/flight_booking/mocks/MockFlightRepository.java
@@ -19,9 +19,6 @@ public class MockFlightRepository implements FlightRepositoryInterface {
   private final String[] destinations = {"Egilsstaðir", "Akureyri", "Vestmannaeyjar", "Egilsstaðir", "Akureyri",
       "Vestmannaeyjar", "Egilsstaðir"};
 
-  /**
-   * Creates a new mock object based on the FlightRepositoryInterface
-   */
   public MockFlightRepository() {
     flights = new ArrayList<>();
     for (int i = 0; i < departures.length; i++) {
@@ -41,19 +38,10 @@ public class MockFlightRepository implements FlightRepositoryInterface {
     }
   }
 
-  /*
-   * getSortedByPrice
-   * 
-   * Raðar lista af flugum eftir verði
-   * 
-   * @return sorted listi af flugum sem er raðað eftir verði
-   * 
-   */
   public Flight getFlight(String flightId) {
     return flights.get(3);
   }
 
-  @Override
   public ArrayList<Flight> getSortedByPrice() {
     ArrayList<Flight> sorted = flights;
     sorted.sort(new Comparator<Flight>() {
@@ -67,15 +55,6 @@ public class MockFlightRepository implements FlightRepositoryInterface {
 
   }
 
-  /*
-   * getSortedByTime
-   * 
-   * Raðar lista af flugum eftir tímaröð
-   * 
-   * @return sorted listi af flugum sem er raðað í tímaröð
-   * 
-   */
-  @Override
   public ArrayList<Flight> getSortedByTime() {
     ArrayList<Flight> sorted = flights;
     sorted.sort(new Comparator<Flight>() {
@@ -87,15 +66,6 @@ public class MockFlightRepository implements FlightRepositoryInterface {
     return sorted;
   }
 
-  /*
-   * getSortedByDeparture
-   * 
-   * Raðar lista af flugum eftir hvaðan flugin koma
-   * 
-   * @return sorted listi af flugum sem er raðað eftir hvaðan þau koma
-   * 
-   */
-  @Override
   public ArrayList<Flight> getSortedByDeparture() {
     ArrayList<Flight> sorted = flights;
     sorted.sort(new Comparator<Flight>() {
@@ -107,15 +77,6 @@ public class MockFlightRepository implements FlightRepositoryInterface {
     return sorted;
   }
 
-  /*
-   * getSortedByArrival
-   * 
-   * Raðar lista af flugum eftir hvert flugin fara
-   * 
-   * @return sorted listi af flugum sem er raðað eftir hvert þau fara
-   * 
-   */
-  @Override
   public ArrayList<Flight> getSortedByArrival() {
     ArrayList<Flight> sorted = flights;
     sorted.sort(new Comparator<Flight>() {
@@ -127,21 +88,6 @@ public class MockFlightRepository implements FlightRepositoryInterface {
     return sorted;
   }
 
-  /*
-   * searchFlight
-   * 
-   * Leitar að flugi/flugum úr lista af flugum
-   * 
-   * @param departureAddress Hvaðan flugið fer frá
-   * 
-   * @param arrivalAddress Hvert flugið er að fara
-   * 
-   * @param departureTime Hvaða dagsetningu flugið fer
-   * 
-   * @return filteredFlights Flug sem uppfylla leitarskilirðin
-   * 
-   */
-  @Override
   public ArrayList<Flight> searchFlights(String departureAddress, String arrivalAddress, LocalDate departureTime) {
     ArrayList<Flight> filteredFlights = new ArrayList<>();
 

--- a/src/test/java/is/hi/flight_booking/mocks/MockFlightRepository.java
+++ b/src/test/java/is/hi/flight_booking/mocks/MockFlightRepository.java
@@ -13,15 +13,16 @@ import is.hi.flight_booking.interfaces.FlightRepositoryInterface;
 
 public class MockFlightRepository implements FlightRepositoryInterface {
 
-  // private Flight[] mockFlights;
   private final ArrayList<Flight> flights;
   private final String[] departures = {"Reykjavík", "Keflavík", "Húsavík", "Reykjavík", "Keflavík", "Keflavík",
       "Keflavík"};
   private final String[] destinations = {"Egilsstaðir", "Akureyri", "Vestmannaeyjar", "Egilsstaðir", "Akureyri",
       "Vestmannaeyjar", "Egilsstaðir"};
 
+  /**
+   * Creates a new mock object based on the FlightRepositoryInterface
+   */
   public MockFlightRepository() {
-    // notum hér sömu gögn og voru skilgrein í testinu
     flights = new ArrayList<>();
     for (int i = 0; i < departures.length; i++) {
       String id = "F-" + (100 + i);
@@ -40,7 +41,7 @@ public class MockFlightRepository implements FlightRepositoryInterface {
     }
   }
 
-      /*
+  /*
    * getSortedByPrice
    * 
    * Raðar lista af flugum eftir verði
@@ -48,7 +49,6 @@ public class MockFlightRepository implements FlightRepositoryInterface {
    * @return sorted listi af flugum sem er raðað eftir verði
    * 
    */
-  @Override
   public Flight getFlight(String flightId) {
     return flights.get(3);
   }
@@ -67,7 +67,7 @@ public class MockFlightRepository implements FlightRepositoryInterface {
 
   }
 
-    /*
+  /*
    * getSortedByTime
    * 
    * Raðar lista af flugum eftir tímaröð
@@ -87,12 +87,12 @@ public class MockFlightRepository implements FlightRepositoryInterface {
     return sorted;
   }
 
-    /*
+  /*
    * getSortedByDeparture
    * 
    * Raðar lista af flugum eftir hvaðan flugin koma
    * 
-   * @return sorted listi af flugum sem er raðað eftir hvaðan þau koma 
+   * @return sorted listi af flugum sem er raðað eftir hvaðan þau koma
    * 
    */
   @Override
@@ -112,7 +112,7 @@ public class MockFlightRepository implements FlightRepositoryInterface {
    * 
    * Raðar lista af flugum eftir hvert flugin fara
    * 
-   * @return sorted listi af flugum sem er raðað eftir hvert þau fara 
+   * @return sorted listi af flugum sem er raðað eftir hvert þau fara
    * 
    */
   @Override
@@ -127,16 +127,18 @@ public class MockFlightRepository implements FlightRepositoryInterface {
     return sorted;
   }
 
-
   /*
    * searchFlight
    * 
    * Leitar að flugi/flugum úr lista af flugum
    * 
-   * @param departureAddress  Hvaðan flugið fer frá
-   * @param arrivalAddress    Hvert flugið er að fara
-   * @param departureTime     Hvaða dagsetningu flugið fer
-   * @return filteredFlights  Flug sem uppfylla leitarskilirðin
+   * @param departureAddress Hvaðan flugið fer frá
+   * 
+   * @param arrivalAddress Hvert flugið er að fara
+   * 
+   * @param departureTime Hvaða dagsetningu flugið fer
+   * 
+   * @return filteredFlights Flug sem uppfylla leitarskilirðin
    * 
    */
   @Override


### PR DESCRIPTION
# Breytingar
- bætti við JavaDoc standard lýsingum fyrir `FlightRepositoryInterface` skjalið
     - þetta leyfir erfingjum þess að nota lýsingarnar aftur svo við fylgjum **DRY (Don't Repeat Yourself)** standardinum
     - með þessu getum við linkað í interface lýsingarnar úr öðrum skrám í stað þess að skrifa þær aftur
- tók út lýsingarnar sem voru komnar inn í `MFR` því þær voru ekki á JavaDoc formi þannig þær birtust ekki í hover og voru yfirskrifaðar af interfaceinu sorry @Gunnarbjo 